### PR TITLE
deps/update-node-forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2905,10 +2905,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }


### PR DESCRIPTION
Updates the node-forge dependency to the latest version to address potential security vulnerabilities. This ensures the project remains secure and up-to-date with the latest patches.

Changes:

- Bumped node-forge from 1.3.3 to [latest version]
- Updated [package-lock.json](vscode-file://vscode-app/c:/Users/salin/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) accordingly

Testing:

- Verified that the application builds and runs without issues after the update.