### PR TITLE
Bump serialize-javascript to 7.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3890,16 +3890,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4197,13 +4187,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "webpack": "^5.105.3",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.3"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.3"
   }
 }


### PR DESCRIPTION
Dependabot detected a vulnerability in `serialize-javascript`, but cannot automatically update it to a patched version. The latest version that can be installed under current dependency constraints is 6.0.2, which remains vulnerable. The earliest fixed version is 7.0.3.

### Solution
Added npm `overrides` configuration to force `serialize-javascript` to version 7.0.3 across all transitive dependencies, including those from `copy-webpack-plugin` and `webpack`. This approach:
- Ensures the patched version is used without requiring direct dependency updates
- Works with npm v8.3.0+ (built-in overrides support)
- Doesn't break existing dependency chains

### Changes
- Added `"overrides": { "serialize-javascript": "7.0.3" }` to `package.json`