### PR TITLE
Bump fast-uri to 3.1.2 to address vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,9 +2336,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
This PR Updates `fast-uri` from `3.1.0` to `3.1.2` to address a reported dependency vulnerability.

## Changes

* Bumped `fast-uri` from `3.1.0` → `3.1.2`
* Updated lockfile integrity hashes accordingly

## Notes

* No application code changes were required
* This is a dependency-only security update
